### PR TITLE
Issue #12: 

### DIFF
--- a/class/User.js
+++ b/class/User.js
@@ -275,7 +275,7 @@ export class User {
     txs = txs.result;
     let result = [];
     for (let tx of txs) {
-      if (tx.confirmations >= 3 && tx.address === addr) {
+      if (tx.confirmations >= 3 && tx.address === addr && tx.category === 'receive') {
         tx.type = 'bitcoind_tx';
         result.push(tx);
       }
@@ -325,7 +325,7 @@ export class User {
     txs = txs.result;
     let result = [];
     for (let tx of txs) {
-      if (tx.confirmations < 3 && tx.address === addr) {
+      if (tx.confirmations < 3 && tx.address === addr && tx.category === 'receive') {
         result.push(tx);
       }
     }

--- a/class/User.js
+++ b/class/User.js
@@ -271,11 +271,11 @@ export class User {
       addr = await this.getAddress();
     }
     if (!addr) throw new Error('cannot get transactions: no onchain address assigned to user');
-    let txs = await this._bitcoindrpc.request('listtransactions', [addr, 100500, 0, true]);
+    let txs = await this._bitcoindrpc.request('listtransactions', ['*', 100500, 0, true]);
     txs = txs.result;
     let result = [];
     for (let tx of txs) {
-      if (tx.confirmations >= 3) {
+      if (tx.confirmations >= 3 && tx.address === addr) {
         tx.type = 'bitcoind_tx';
         result.push(tx);
       }
@@ -321,11 +321,11 @@ export class User {
       addr = await this.getAddress();
     }
     if (!addr) throw new Error('cannot get transactions: no onchain address assigned to user');
-    let txs = await this._bitcoindrpc.request('listtransactions', [addr, 100500, 0, true]);
+    let txs = await this._bitcoindrpc.request('listtransactions', ['*', 100500, 0, true]);
     txs = txs.result;
     let result = [];
     for (let tx of txs) {
-      if (tx.confirmations < 3) {
+      if (tx.confirmations < 3 && tx.address === addr) {
         result.push(tx);
       }
     }


### PR DESCRIPTION
Change to fetch all on-chain txs (for imported addresses on bitcoind) and do local filtering based on user's address. This permits running LndHub without -deprecatedrpc=accounts switch and ensures each user of the hub only sees its own transactions and balance.

**Note**: Perhaps the method (or content of this pull request) I have used to propose this simple change (using a fork) isn't what you expected. I am 100% new to GitHub and open source collaboration so I gladly take any advice on any aspect and make it 99.999%.