### PR TITLE
Add Dockerfile example with npm build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get -y --no-install-recommends install npm=* nodejs=* \
+     build-essential=* \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY . /lndhub
+WORKDIR /lndhub
+RUN npm i && npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon node_modules/.bin/babel-node index.js",
-    "start": "node_modules/.bin/babel-node index.js",
+    "build": "babel ./ -d dist --copy-files --ignore node_modules",
+    "start": "node dist/index.js",
     "lint": "./node_modules/.bin/eslint ./ controllers/ class/ --fix"
   },
   "author": "Igor Korsakov <overtorment@gmail.com>",


### PR DESCRIPTION
Using the [a guide from the README](https://github.com/dangeross/guides/blob/master/raspibolt/raspibolt_6B_lndhub.md), I thought it might be helpful to have a simple Dockerfile example.

I also added a npm build script to simplify building the project and allow for using the start script in production. I used [this production guide](https://github.com/babel/example-node-server#getting-ready-for-production-use) for reference. 