### PR TITLE
Fixed progress bar css for small values

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -112,8 +112,10 @@ body {
 	appearance: none;
 	margin: 0;
 	padding: 0;
-	max-width : 100%;
+	max-width: 100%;
 	-webkit-appearance: none;
+	border-radius: 8px;
+	overflow: hidden;
 }
 #progressbar[max]::-webkit-progress-value {
 	border-radius: 8px 4px 4px 8px;


### PR DESCRIPTION
<img width="340" alt="Screenshot 2021-04-08 at 16 59 04" src="https://user-images.githubusercontent.com/18405140/114049444-be914680-988b-11eb-9ead-f0ed5ece956d.png">

this looked weird