### PR TITLE
README.md: clean up and remove 'deprecatedrpc' recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LndHub
 ======
 
-Wrapper for Lightning Network Daemon. It provides separate accounts with minimum trust for end users
+Wrapper for Lightning Network Daemon (lnd). It provides separate accounts with minimum trust for end users.
 
 INSTALLATION
 ------------
@@ -17,15 +17,17 @@ cd LndHub
 npm i
 ```
 
-Install `bitcoind`, `lnd` and `redis`. Edit `config.js` and set it up correctly.
-Copy `admin.macaroon` and `tls.cert` in root folder of LndHub.
+Install `bitcoind`, `lnd`, and `redis`. Edit LndHub's `config.js` to set it up correctly.
+Copy the files `admin.macaroon` (for Bitcoin mainnet, usually stored in `~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`)
+and `tls.cert` (usually stored in `~/.lnd/tls.cert`) into the root folder of LndHub.
 
-`bitcoind` should run with `-deprecatedrpc=accounts`, for now. Lndhub expects Lnd's wallet to be unlocked, if not - it will attempt to unlock it with password stored in `config.lnd.password`.
-Don't forget to enable disk-persistance for `redis`.
+LndHub expects LND's wallet to be unlocked, if not — it will attempt to unlock it with the password stored in `config.lnd.password`.
+Don't forget to configure disk-persistence for `redis` (e.g., you may want to set `appendonly` to  `yes` in `redis.conf` (see
+http://redis.io/topics/persistence for more information).
 
 If you have no `bitcoind` instance, for example if you use neutrino, or you have no bitcoind wallet, 
 for example if you use LND for wallet managment, you can remove the bitcoind settings from `config.js`.
-Please not that this feature is limited to Bitcoin, so you can't use this feature if you use any other cryptocurrency with LND.
+Please not that this feature is limited to Bitcoin, so you can't use it if you use any other cryptocurrency with LND (e.g., Litecoin).
 
 ### Deploy to Heroku
 
@@ -57,5 +59,5 @@ Acceptance tests are in https://github.com/BlueWallet/BlueWallet/blob/master/Lig
 
 ## Responsible disclosure
 
-Found critical bugs/vulnerabilities? Please email them bluewallet@bluewallet.io
+Found critical bugs/vulnerabilities? Please email them to bluewallet@bluewallet.io
 Thanks!


### PR DESCRIPTION
According to this comment [here](https://github.com/BlueWallet/LndHub/issues/39), `--deprecatedrpc=accounts` should no longer be needed, so I updated that.

Besides, I added some explanations that would have helped me while setting up LndHub.