### PR TITLE
accounttype and partnerid check on create account

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -133,8 +133,12 @@ const postLimiter = rateLimit({
 
 router.post('/create', postLimiter, async function (req, res) {
   logger.log('/create', [req.id]);
-  if (!(req.body.partnerid && req.body.partnerid === 'bluewallet' && req.body.accounttype)) return errorBadArguments(res);
-
+  // Valid if the partnerid isn't there or is a string (same with accounttype)
+  if (! (
+        (!req.body.partnerid || (typeof req.body.partnerid === 'string' || req.body.partnerid instanceof String))
+        && (!req.body.accounttype || (typeof req.body.accounttype === 'string' || req.body.accounttype instanceof String))
+      ) ) return errorBadArguments(res);
+  
   if (config.sunset) return errorSunset(res);
 
   let u = new User(redis, bitcoinclient, lightning);


### PR DESCRIPTION
Refined the partnerid and accounttype check in the /create route according to the /doc/Send-requirements.md
Both are not mandatory but if given, they should be strings.

The typeof check is for direct string initialisation with "".
instanceof is used for string initialisation with new String() / the primitiv wrapper class.
I'm not 100% sure which way is used there so I've put both ways in. 

Also, please control it, I've not tested it #296 