### PR TITLE
Update node from 12-buster to 16-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN adduser --disabled-password \
             --gecos "" \
             "lndhub"
 
-FROM node:12-buster-slim AS builder
+FROM node:16-bullseye-slim AS builder
 
 # These packages are required for building LNDHub
 RUN apt-get update && apt-get -y install python3
@@ -25,7 +25,7 @@ COPY . .
 # Delete git data as it's not needed inside the container
 RUN rm -rf .git
 
-FROM node:12-buster-slim
+FROM node:16-bullseye-slim
 
 # Create a specific user so LNDHub doesn't run as root
 COPY  --from=perms /etc/group /etc/passwd /etc/shadow  /etc/


### PR DESCRIPTION
With Node 16 and Debian Bullseye being out now, this updates the BlueWallet docker containers to these versions. On Citadel, this will allow faster downloads of the app because it always uses the up-to-date containers, and when (if) Umbrel migrates to Node 16, it'll also allow faster downloads there.

Also, with the docker container now being up-to-date, and Node 12 being the oldest still maintained node version, I don't think babel is still useful, so maybe that could be dropped in the future too to reduce the size of the docker container and the amount of dependencies.

@Overtorment