### PR TITLE
Add the transpiled artifacts to build/ for a slimmer native Node Dock…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+*
+!build/
+!class/
+!controllers/
+!scripts/
+!static/
+!templates/
+!utils/
+!*.js
+!.babelrc
+!.eslint*
+!admin.macaroon
+!package*.json
+!rpc.proto
+!tls.cert

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 admin.macaroon
 tls.cert
+build/
 logs/
 
 # dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,17 @@ RUN apt-get update && apt-get -y install python3
 
 WORKDIR /lndhub
 
-# Copy 'package-lock.json' and 'package.json'
-COPY package.json package-lock.json ./
+# Copy project files and folders to the current working directory
+COPY . .
 
 # Install dependencies
 RUN npm i
-
-# Copy project files and folders to the current working directory
-COPY . .
+RUN npm run build
 
 # Delete git data as it's not needed inside the container
 RUN rm -rf .git
 
-FROM node:16-bullseye-slim
+FROM node:16-alpine
 
 # Create a specific user so LNDHub doesn't run as root
 COPY  --from=perms /etc/group /etc/passwd /etc/shadow  /etc/
@@ -34,10 +32,11 @@ COPY  --from=perms /etc/group /etc/passwd /etc/shadow  /etc/
 COPY  --from=builder /lndhub /lndhub
 
 # Create logs folder and ensure permissions are set correctly
-RUN mkdir /lndhub/logs && chown -R lndhub:lndhub /lndhub
+RUN mkdir -p /lndhub/logs && chown -R lndhub:lndhub /lndhub
 USER lndhub
 
 ENV PORT=3000
 EXPOSE 3000
+WORKDIR /lndhub
 
 CMD cp $LND_CERT_FILE /lndhub/ && cp $LND_ADMIN_MACAROON_FILE /lndhub/ && cd /lndhub && npm start

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -5,7 +5,9 @@ let express = require('express');
 let router = express.Router();
 let logger = require('../utils/logger');
 const MIN_BTC_BLOCK = 670000;
-console.log('using config', JSON.stringify(config));
+if (process.env.NODE_ENV !== 'prod') {
+  console.log('using config', JSON.stringify(config));
+}
 
 var Redis = require('ioredis');
 var redis = new Redis(config.redis);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "./node_modules/.bin/babel ./ --ignore node_modules/ --ignore *.spec.js --out-dir ./build",
     "dev": "nodemon node_modules/.bin/babel-node index.js",
     "start": "node_modules/.bin/babel-node index.js",
     "lint": "./node_modules/.bin/eslint ./ controllers/ class/ --fix"


### PR DESCRIPTION
This adds the transpiled artifacts to a new `build/` directory for a slimmer (node:16-alpine) Docker image that does not require babel-node. This is a first iteration that makes LndHub run in our environment, I'm contributing this upstream in case it helps anyone. If it is appreciated, I have some future improvements in the pipeline. :)