### PR TITLE
fix: displays correct wallet balance when running on regtest without bitcoin core

### DIFF
--- a/class/User.js
+++ b/class/User.js
@@ -442,7 +442,7 @@ export class User {
         transactions
           .filter((tx) => tx.label !== 'external' && !tx.label.includes('openchannel'))
           .map((tx) => {
-            const decodedTx = decodeRawHex(tx.raw_tx_hex);
+            const decodedTx = decodeRawHex(tx.raw_tx_hex, config.network);
             decodedTx.outputs.forEach((vout) =>
               outTxns.push({
                 // mark all as received, since external is filtered out

--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
+const bitcoin = require('bitcoinjs-lib')
 let config = {
+  network: bitcoin.networks.bitcoin,
   enableUpdateDescribeGraph: false,
   postRateLimit: 100,
   rateLimit: 200,


### PR DESCRIPTION
This is done by simply introducing the desired network in the configuration file.

This solves issue #379.